### PR TITLE
common: remove unused variable apt_add_proxmox_repository

### DIFF
--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -22,7 +22,7 @@ All components can be enabled/disabled independently
 
 In addition, this role provides a procedure to upgrade Debian 10 hosts to Debian 11. The tag `utils-debian10to11` must be passed explicitly for this procedure to run.
 
-## Requirements/Dependencies/example playbook
+## Requirements/dependencies/example playbook
 
 See [meta/main.yml](meta/main.yml)
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -114,12 +114,10 @@ ssh_allow_tcp_forwarding: "no"
 ssh_permit_root_login: "no"
 # enable/disable SSH password authentication (yes, no - QUOTED)
 ssh_password_authentication: "no"
-
 # SSH Server allowed Key Exchange alogrithms
 # Add other KexAlgortithms here if your clients do not support modern/secure KEX
 ssh_kexalgorithms:
   - diffie-hellman-group-exchange-sha256
-
 # SSH Server allowed HMACs (hash alogrithms)
 # Add other HMAC alogrithms here if your clients do not support modern/secure HMACs
 ssh_hmacs:
@@ -277,6 +275,3 @@ setup_haveged: yes
 # yes/no: install extra CA certificates to the OS trust store
 # place certificate files in a `certificates/` directory at the root of the playbook, named `*.crt`
 install_ca_certificates: no
-
-# yes/no: add the proxmox 'no-subscription' APT repository to sources.list
-apt_add_proxmox_repository: no

--- a/roles/common/tasks/ca-certificates.yml
+++ b/roles/common/tasks/ca-certificates.yml
@@ -1,5 +1,3 @@
----
-
 - name: copy CA certificates
   copy:
     src: "{{ item }}"


### PR DESCRIPTION
- this variable is not used anywhere and has no effect
- sources for unattended-upgrades are managed by `apt_unattended_upgrades_origins_patterns`, proxmox automatic upgrades are enabled by default

