### PR TITLE
common: make cron log level configurable, default to 7

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -237,6 +237,8 @@ linux_users: []
 setup_cron: yes
 # list of users allowed to use crontab for task scheduling
 linux_users_crontab_allow: ['root']
+# cron jobs log level (cumulative, https://manpages.debian.org/bullseye/cron/cron.8.en.html#OPTIONS)
+cron_log_level: 7
 
 ### OUTGOING MAIL ###
 # (yes/no) install outgoing system mail (msmtp)

--- a/roles/common/tasks/checks.yml
+++ b/roles/common/tasks/checks.yml
@@ -9,6 +9,7 @@
       - apt_unattended_upgrades_origins_patterns|type_debug == "list"
       - setup_cli_utils == setup_cli_utils|bool
       - setup_cron == setup_cron|bool
+      - cron_log_level == cron_log_level|int
       - setup_dns == setup_dns|bool
       - setup_hostname == setup_hostname|bool
       - setup_firewall == setup_firewall|bool

--- a/roles/common/templates/etc_default_cron.j2
+++ b/roles/common/templates/etc_default_cron.j2
@@ -24,5 +24,5 @@ READ_ENV="yes"
 #   4   log jobs with exit status != 0
 #   8   log the process identifier of child process (in all logs)
 #
-EXTRA_OPTS="-n -L 7"
+EXTRA_OPTS="-n -L {{ cron_log_level }}"
 


### PR DESCRIPTION
- https://manpages.debian.org/bullseye/cron/cron.8.en.html#OPTIONS
```
    as the sum of the following values:
    1 will log the start of all cron jobs
    2 will log the end of all cron jobs
    4 will log all failed jobs (exit status != 0)
    8 will log the process number of all cron jobs
```