### PR TITLE
common: fail2ban: remove duplicate tasks

### DIFF
--- a/roles/common/tasks/fail2ban.yml
+++ b/roles/common/tasks/fail2ban.yml
@@ -61,20 +61,3 @@
 
 - name: apply configuration (flush handlers)
   meta: flush_handlers
-
-##### FACTS #####
-
-- name: create ansible facts.d directory
-  file:
-    path: /etc/ansible/facts.d
-    state: directory
-    mode: 0755
-  ignore_errors: "{{ ansible_check_mode }}"
-
-- name: create fail2ban fact file
-  template:
-    src: etc_ansible_facts.d_fail2ban.fact.j2
-    dest: /etc/ansible/facts.d/fail2ban.fact
-    mode: 0644
-  notify: update ansible facts
-  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
- 'create ansible facts.d directory'/'create fail2ban fact file called' twice