### PR TITLE
apache: allow aggregating apache access logs to syslog

### DIFF
--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -11,8 +11,10 @@ apache_allow_robots: yes
 apache_enable_service: yes
 # yes/no: enable mod_evasive for basic DoS protection (can interfere with legitimate traffic)
 apache_enable_mod_evasive: no
-# e-mail address to register a letsencrypt.org account when mod-md is used
+# e-mail address to register a letsencrypt.org account
 apache_letsencrypt_email: "CHANGEME"
+# yes/no: aggregate apache access logs to syslog (if monitoring_rsyslog role is deployed)
+apache_access_log_to_syslog: no
 # list of apache reverse proxies. Each item has the following attributes:
 #   servername (required): servername/Host header to match
 #   upstream: URL to proxy to (without trailing slash)

--- a/roles/apache/tasks/checks.yml
+++ b/roles/apache/tasks/checks.yml
@@ -7,3 +7,4 @@
       - apache_letsencrypt_email is not search("CHANGEME")
       - apache_listen_http == apache_listen_http|bool
       - apache_allow_robots == apache_allow_robots|bool
+      - apache_access_log_to_syslog == apache_access_log_to_syslog|bool

--- a/roles/apache/templates/etc_rsyslog.d_apache.conf.j2
+++ b/roles/apache/templates/etc_rsyslog.d_apache.conf.j2
@@ -5,3 +5,11 @@ input(type="imfile"
       Tag="apache:"
       Facility="daemon"
       PersistStateInterval="0")
+
+{% if apache_access_log_to_syslog %}
+input(type="imfile"
+      File="/var/log/apache2/access.log"
+      Tag="apache-access:"
+      Facility="daemon"
+      PersistStateInterval="0")
+{% endif %}


### PR DESCRIPTION
- if the monitoring_rsyslog role is deployed AND `apache_access_log_to_syslog: yes` (default `no`)