### PR TITLE
openldap: replace netdata process check with more accurate systemd service check

### DIFF
--- a/roles/openldap/tasks/netdata.yml
+++ b/roles/openldap/tasks/netdata.yml
@@ -1,4 +1,4 @@
-- name: add netdata http (ldap-account-manager/self-service-password)/process checks for openldap
+- name: install netdata http/systemd checks for openldap
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -6,8 +6,15 @@
     group: netdata
     mode: 0640
   notify: assemble netdata configuration
+  ignore_errors: "{{ ansible_check_mode }}"
   with_items:
     - src: etc_netdata_go.d_httpcheck.conf.d_openldap.conf.j2
       dest: /etc/netdata/go.d/httpcheck.conf.d/openldap.conf
-    - src: etc_netdata_health.d_processes.conf.d_openldap.conf.j2
-      dest: /etc/netdata/health.d/processes.conf.d/openldap.conf
+    - src: etc_netdata_health.d_systemdunits.conf.d_openldap.conf.j2
+      dest: /etc/netdata/health.d/systemdunits.conf.d/openldap.conf
+
+- name: remove files from old versions of the role
+  file:
+    state: absent
+    path: "/etc/netdata/health.d/processes.conf.d/openldap.conf"
+  notify: assemble netdata configuration

--- a/roles/openldap/tasks/self-service-password-ssl-selfsigned.yml
+++ b/roles/openldap/tasks/self-service-password-ssl-selfsigned.yml
@@ -1,5 +1,3 @@
-##### SSL/TLS CERTIFICATES - SELF-SIGNED #####
-
 - name: install requirements for SSL/TLS certificates generation
   apt:
     state: present

--- a/roles/openldap/templates/etc_netdata_health.d_processes.conf.d_openldap.conf.j2
+++ b/roles/openldap/templates/etc_netdata_health.d_processes.conf.d_openldap.conf.j2
@@ -1,8 +1,0 @@
- alarm: auth_processes
-    on: apps.processes
-  calc: $auth
- every: 20s
-  crit: ($this < 1) OR ($this = nan)
- units: processes
-  info: authentication services (ldap) running processes
-    to: sysadmin

--- a/roles/openldap/templates/etc_netdata_health.d_systemdunits.conf.d_openldap.conf.j2
+++ b/roles/openldap/templates/etc_netdata_health.d_systemdunits.conf.d_openldap.conf.j2
@@ -1,0 +1,8 @@
+ alarm: systemd_service_slapd
+    on: systemdunits_service_units.service_unit_state
+  calc: $slapd
+ every: 10s
+  crit: ($this = 5)
+ units: state
+  info: openldap server service status
+    to: sysadmin


### PR DESCRIPTION
- if the monitoring_netdata role is deployed
- standardize comments