### PR TITLE
common: ssh: increase the frequency of "client alive" messages to 1 every 5 minutes

### DIFF
--- a/roles/common/templates/etc_ssh_sshd_config.j2
+++ b/roles/common/templates/etc_ssh_sshd_config.j2
@@ -108,8 +108,9 @@ GSSAPICleanupCredentials yes
 # Disable TCP keep alive since it is spoofable. Use ClientAlive messages instead, they use the encrypted channel
 TCPKeepAlive no
 
-# Manage `ClientAlive..` signals via interval and maximum count. This will periodically check up to a `..CountMax` number of times within `..Interval` timeframe, and abort the connection once these fail.
-ClientAliveInterval 600
+# Send "client alive" messages to all clients every ClientAliveInterval seconds
+# Disconnect any clients not responding to "client alive" messages after ClientAliveCountMax number of messages
+ClientAliveInterval 300
 ClientAliveCountMax 3
 
 # Disable tunneling


### PR DESCRIPTION
- fixes lynis warning SSH-7408|Consider hardening SSH configuration|ClientAliveInterval (set 600 to 300)