### PR TITLE
common: automatically remove (purge) configuration files of removed packages, nightly, enabled by default (apt_purge_nightly: yes/no)

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -33,6 +33,8 @@ os_security_kernel_enable_core_dump: no
 setup_apt: yes
 # yes/no: enable 'contrib' and 'non-free' software sections in debian APT repositories
 apt_enable_nonfree: no
+# yes/no: automatically remove (purge) configuration files of removed packages, nightly
+apt_purge_nightly: yes
 # yes/no: setup apt-listbugs (Debian only)
 apt_listbugs: yes
 # Debian bug numbers/packages to ignore for apt-listbugs (don't let these bugs block package installation)

--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -17,6 +17,17 @@
     - { src: 'etc_apt_apt.conf.d_50unattended-upgrades.j2', dest: '/etc/apt/apt.conf.d/50unattended-upgrades' }
     - { src: 'etc_apt_apt.conf.d_99-autoremove.j2', dest: '/etc/apt/apt.conf.d/99-autoremove' }
 
+- name: enable/disable nightly purge of removed packages configuration files
+  cron:
+    user: root
+    cron_file: apt-purge
+    name: "purge configuration files of removed packages"
+    minute: "00"
+    hour: "23"
+    day: "*"
+    job: aptitude -q -y purge ~c 2>&1 | logger -t apt-purge
+    disabled: "{{ False if apt_purge_nightly else True }}"
+
 - name: remove files from old versions of the role
   file:
     path: "{{ item }}"

--- a/roles/common/tasks/checks.yml
+++ b/roles/common/tasks/checks.yml
@@ -6,6 +6,7 @@
       - linux_users|type_debug == "list"
       - os_security_kernel_enable_core_dump == os_security_kernel_enable_core_dump|bool
       - setup_apt == setup_apt|bool
+      - apt_purge_nightly == apt_purge_nightly | bool
       - apt_unattended_upgrades_origins_patterns|type_debug == "list"
       - setup_cli_utils == setup_cli_utils|bool
       - setup_cron == setup_cron|bool


### PR DESCRIPTION
 - fixes lynis suggestion PKGS-7346|Purge old/removed packages