### PR TITLE
common: ssh: replace the server's default 2048 bits RSA keypair with 4096 bits keypair

### DIFF
--- a/roles/common/tasks/ssh.yml
+++ b/roles/common/tasks/ssh.yml
@@ -57,6 +57,18 @@
   notify: restart ssh
   when: sshd_register_moduli.stdout
 
+- name: replace default 2048 bits RSA keypair with 4096 bits keypair
+  openssh_keypair:
+    state: present
+    type: rsa
+    size: 4096
+    path: "/etc/ssh/ssh_host_rsa_key"
+    force: no
+    regenerate: partial_idempotence
+    owner: root
+    group: root
+    mode: "0600"
+
 # lynis: FILE-7524|Incorrect permissions for file /root/.ssh
 - name: ensure /root/.ssh is mode 0700
   file:


### PR DESCRIPTION
- ref. https://github.com/dev-sec/ansible-collection-hardening/pull/376
> According to NIST standards, achieving a security strength of 128 (2019 - 2030 & beyond) requires a factoring modulus with a length of at least 3072 bits, and since there is no major performance difference between RSA of size 2048 bits and RSA of size 4096 bits keys, it's better to ship SSH with RSA key of size 4096 bits.
- https://www.keylength.com/en/4/