### PR TITLE
common: apt: use https:// instead of http:// in sources list

### DIFF
--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -1,3 +1,8 @@
+- name: install packages for HTTPS APT sources support
+  apt:
+    state: present
+    package: apt-transport-https
+
 - name: copy apt sources lists (debian + security + backports)
   template:
     src: "etc_apt_sources.list.j2"

--- a/roles/common/templates/etc_apt_sources.list.j2
+++ b/roles/common/templates/etc_apt_sources.list.j2
@@ -1,16 +1,16 @@
-deb http://deb.debian.org/debian/ {{ ansible_facts.distribution_release }} main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
-# deb-src http://deb.debian.org/debian/ {{ ansible_facts.distribution_release }} main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+deb https://deb.debian.org/debian/ {{ ansible_facts.distribution_release }} main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+# deb-src https://deb.debian.org/debian/ {{ ansible_facts.distribution_release }} main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
 
 {% if ansible_facts.distribution == 'Debian' and ansible_facts.distribution_release == 'bullseye' %}
-deb http://security.debian.org/debian-security {{ ansible_facts.distribution_release }}-security main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+deb https://security.debian.org/debian-security {{ ansible_facts.distribution_release }}-security main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
 # deb-src http://security.debian.org/debian-security {{ ansible_facts.distribution_release }}-security main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
 {% elif ansible_facts.distribution == 'Debian' %}
-deb http://security.debian.org/debian-security {{ ansible_facts.distribution_release }}/updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
-# deb-src http://security.debian.org/debian-security {{ ansible_facts.distribution_release }}/updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+deb https://security.debian.org/debian-security {{ ansible_facts.distribution_release }}/updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+# deb-src https://security.debian.org/debian-security {{ ansible_facts.distribution_release }}/updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
 {% endif %}
 
-deb http://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
-# deb-src http://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+deb https://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+# deb-src https://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-updates main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
 
-deb http://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-backports main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
-# deb-src http://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-backports main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+deb https://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-backports main{% if apt_enable_nonfree %} contrib non-free{% endif +%}
+# deb-src https://deb.debian.org/debian/ {{ ansible_facts.distribution_release }}-backports main{% if apt_enable_nonfree %} contrib non-free{% endif +%}


### PR DESCRIPTION
- even though packages downloaded from APT repositories are cryptographically signed, this prevents possible attacks by a malicious mirror/man-in-the-middle, where the attacker could cause APT to execute arbitrary code through specially crafted headers or other means.
- https://justi.cz/security/2019/01/22/apt-rce.html
- https://www.debian.org/security/2016/dsa-3733