### PR TITLE
feat(others_path): add reverse proxy multiple path capabilities

### DIFF
--- a/roles/apache/tasks/apache.yml
+++ b/roles/apache/tasks/apache.yml
@@ -122,6 +122,8 @@
       dest: /etc/apache2/sites-available/000-sites.conf
     - src: etc_apache2_sites-available_reverseproxy.conf.j2
       dest: /etc/apache2/sites-available/reverseproxy.conf
+  tags:
+    - reverseproxy
 
 - name: enable apache sites configuration
   command: a2ensite {{ item }}

--- a/roles/apache/templates/etc_apache2_sites-available_reverseproxy.conf.j2
+++ b/roles/apache/templates/etc_apache2_sites-available_reverseproxy.conf.j2
@@ -21,6 +21,10 @@
   ProxyPass /{{item.wss_proxypass }} {{ item.wss_upstream }}/{{ item.wss_proxypass }}
   ProxyPassReverse /{{item.wss_proxypass }} {{ item.wss_upstream }}/{{ item.wss_proxypass }}
 {% endif %}
+{% for other_path in item.others_path|default([]) %}
+  ProxyPass {{ other_path.path}} {{ other_path.upstream }}
+  ProxyPassReverse {{ other_path.path}} {{ other_path.upstream }}
+{% endfor %}
   ProxyPass / {{ item.upstream }}/
   ProxyPassReverse / {{ item.upstream }}/
 
@@ -77,6 +81,10 @@ MDRequireHttps permanent
   ProxyPass /{{item.wss_proxypass }} {{ item.wss_upstream }}/{{ item.wss_proxypass }}
   ProxyPassReverse /{{item.wss_proxypass }} {{ item.wss_upstream }}/{{ item.wss_proxypass }}
 {% endif %}
+{% for other_path in item.others_path|default([]) %}
+  ProxyPass {{ other_path.path}} {{ other_path.upstream }}
+  ProxyPassReverse {{ other_path.path}} {{ other_path.upstream }}
+{% endfor %}
   ProxyPass / {{ item.upstream }}/
   ProxyPassReverse / {{ item.upstream }}/
 </VirtualHost>


### PR DESCRIPTION
apache_reverseproxies:
  - servername: "hostname"
    upstream: "http://upstreamhostname:port/"
    others_path:
      - path: "/v2/"
        upstream: "http://upstreamhostname:portv2/pathv2/"

will generate on reverseproxy.conf :

  ProxyPass /v2/ http://upstreamhostnamev2:portv2/pathv2/
  ProxyPassReverse /v2/ http://upstreamhostnamev2:portv2/pathv2/
  ProxyPass / http://upstreamhostname:port/
  ProxyPassReverse / http://upstreamhostname:port/
